### PR TITLE
Fix attribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "version": "0.1.0",
   "description": "A plugin for inio light lamps",
   "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/reckter/homebridge-inio.git"
-  },
+  "repository": "reckter/homebridge-inio",
   "bugs": {
     "url": "https://github.com/reckter/homebridge-inio/issues"
   },
@@ -47,7 +44,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
-  "author": "Hannes <hannes@guedelhoefer.de>",
+  "author": "Hannes Güdelhöfer<hannes@guedelhoefer.de>",
   "auto": {
     "plugins": [
       "npm",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.1--canary.2.4188955332.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install homebridge-inio@0.2.1--canary.2.4188955332.0
  # or 
  yarn add homebridge-inio@0.2.1--canary.2.4188955332.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
